### PR TITLE
Feature/eventsfor ios

### DIFF
--- a/Samples/Samples/Converters/TimeSelectedEventArgsConverter.cs
+++ b/Samples/Samples/Converters/TimeSelectedEventArgsConverter.cs
@@ -13,7 +13,7 @@ namespace Samples.Converters
         {
             var eventArgs = value as PropertyChangedEventArgs;
 
-            if (eventArgs == null || eventArgs.PropertyName != nameof(TimePicker.TimeProperty))
+            if (eventArgs == null || eventArgs.PropertyName != nameof(TimePicker.Time))
                 return null;
 
             return eventArgs.PropertyName;

--- a/Samples/Samples/View/CalendarEventPage.xaml
+++ b/Samples/Samples/View/CalendarEventPage.xaml
@@ -62,7 +62,7 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
-                <Label Text="Description"/>
+                <Label Text="Description:"/>
                 <Label Grid.Column="1"
                    Text="{Binding Description}"/>
             </Grid>

--- a/Samples/Samples/View/CalendarEventPage.xaml
+++ b/Samples/Samples/View/CalendarEventPage.xaml
@@ -9,58 +9,63 @@
              x:DataType="essentials:Event"
              Title="Event"
              Padding="20,20,20,20">
+    <views:BasePage.Resources>
+        <ResourceDictionary>
+            <x:String x:Key="DateDisplayFormatter">{0:dd/MM/yy hh:mm tt}</x:String>
+        </ResourceDictionary>
+    </views:BasePage.Resources>
     <views:BasePage.Content>
-      <StackLayout>
-          <Label Text="{Binding Title}"
+        <StackLayout>
+            <Label Text="{Binding Title}"
                  FontSize="34"
                  TextColor="Black"
                  HorizontalTextAlignment="Center"/>
-          <Grid>
-              <Grid.ColumnDefinitions>
-                  <ColumnDefinition/>
-                  <ColumnDefinition/>
-                  <ColumnDefinition Width="Auto"/>
-                  <ColumnDefinition/>
-              </Grid.ColumnDefinitions>
-              <Grid.RowDefinitions>
-                  <RowDefinition Height="Auto"/>
-                  <RowDefinition Height="Auto"/>
-                  <RowDefinition Height="Auto"/>
-                  <RowDefinition/>
-              </Grid.RowDefinitions>
-              <Label Grid.Row="1"
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <Label Grid.Row="1"
                      Grid.Column="0"
                      Text="Location:"/>
-              <Label Grid.Row="1"
+                <Label Grid.Row="1"
                      Grid.Column="1"
                      Grid.ColumnSpan="3"
                      Text="{Binding Location}"/>
-              <Label Grid.Row="2"
+                <Label Grid.Row="2"
                      Grid.Column="0"
                      Text="When:"/>
-              <Label Grid.Column="1"
+                <Label Grid.Column="1"
                      Grid.Row="2"
-                     Text="{Binding StartDate, StringFormat='{0:dd/MM/yy hh:mm tt}'}"
+                     Text="{Binding StartDate, StringFormat={StaticResource DateDisplayFormatter}}"
                      TextColor="Black"
                      HorizontalTextAlignment="Center"/>
-              <Label Grid.Column="2"
+                <Label Grid.Column="2"
                      Grid.Row="2"
                      Text="-"/>
-              <Label Grid.Column="3"
+                <Label Grid.Column="3"
                      Grid.Row="2"
-                     Text="{Binding EndDate, StringFormat='{0:dd/MM/yy hh:mm tt}'}"
+                     Text="{Binding EndDate, StringFormat={StaticResource DateDisplayFormatter}}"
                      TextColor="Black"
                      HorizontalTextAlignment="Center"/>
-          </Grid>
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition/>
-            </Grid.ColumnDefinitions>
-            <Label Text="Description"/>
-            <Label Grid.Column="1"
+            </Grid>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Label Text="Description"/>
+                <Label Grid.Column="1"
                    Text="{Binding Description}"/>
-        </Grid>
-      </StackLayout>
+            </Grid>
+        </StackLayout>
     </views:BasePage.Content>
 </views:BasePage>

--- a/Samples/Samples/View/CalendarPage.xaml
+++ b/Samples/Samples/View/CalendarPage.xaml
@@ -11,6 +11,7 @@
                  Title="Calendars">
   <views:BasePage.Resources>
     <ResourceDictionary>
+     <x:String x:Key="DateDisplayFormatter">{0:dd/MM/yy hh:mm tt}</x:String>
       <converters:CheckBoxEventArgsConverter x:Key="CheckBoxEventArgsConverter"/>
       <converters:DateSelectedEventArgsConverter x:Key="DateSelectedEventArgsConverter"/>
       <converters:TimeSelectedEventArgsConverter x:Key="TimeSelectedEventArgsConverter"/>
@@ -29,13 +30,13 @@
                      TextColor="Black"
                      HorizontalTextAlignment="Center"/>
               <Label Grid.Column="1"
-                     Text="{Binding StartDate, StringFormat='{0:dd/MM/yy hh:mm tt}'}"
+                     Text="{Binding StartDate, StringFormat={StaticResource DateDisplayFormatter}}"
                      TextColor="Black"
                      HorizontalTextAlignment="Center"/>
               <Label Grid.Column="2"
                      Text="-"/>
               <Label Grid.Column="3"
-                     Text="{Binding EndDate, StringFormat='{0:dd/MM/yy hh:mm tt}'}"
+                     Text="{Binding EndDate, StringFormat={StaticResource DateDisplayFormatter}}"
                      TextColor="Black"
                      HorizontalTextAlignment="Center"/>
             </Grid>

--- a/Samples/Samples/View/CalendarPage.xaml
+++ b/Samples/Samples/View/CalendarPage.xaml
@@ -8,7 +8,7 @@
                  xmlns:essentials="clr-namespace:Xamarin.Essentials;assembly=Xamarin.Essentials"
                  x:Class="Samples.View.CalendarPage"
                  x:DataType="viewmodels:CalendarViewModel"
-                 Title="Calendars">
+                 Title="Calendar">
   <views:BasePage.Resources>
     <ResourceDictionary>
      <x:String x:Key="DateDisplayFormatter">{0:dd/MM/yy hh:mm tt}</x:String>
@@ -152,7 +152,13 @@
         <TimePicker Time="{Binding EndTime}"
                     IsEnabled="{Binding EndDatePickersEnabled}"
                     Grid.Row = "1"
-                    Grid.Column="3"/>
+                    Grid.Column="3">
+            <TimePicker.Behaviors>
+                <behaviors:EventToCommandBehavior EventName="PropertyChanged"
+                                                  Command="{Binding EndTimeSelectedCommand}"
+                                                  Converter="{StaticResource TimeSelectedEventArgsConverter}"/>
+            </TimePicker.Behaviors>
+        </TimePicker>
       </Grid>
       <BoxView Grid.Row="3"
                VerticalOptions="Center"

--- a/Samples/Samples/View/CalendarPage.xaml.cs
+++ b/Samples/Samples/View/CalendarPage.xaml.cs
@@ -20,7 +20,7 @@ namespace Samples.View
 
             var modal = new CalendarEventPage();
             modal.BindingContext = e.Item as Event;
-            Navigation.PushModalAsync(modal);
+            Navigation.PushAsync(modal);
         }
     }
 }

--- a/Samples/Samples/ViewModel/CalendarViewModel.cs
+++ b/Samples/Samples/ViewModel/CalendarViewModel.cs
@@ -189,8 +189,6 @@ namespace Samples.ViewModel
 
         async void RefreshEventList(string calendarId = null, DateTime? startDate = null, DateTime? endDate = null)
         {
-            await Calendar.RequestCalendarReadAccess();
-
             startDate = StartDatePickersEnabled && !startDate.HasValue ? (DateTime?)StartDate.Date + StartTime : startDate;
             endDate = (EndDatePickersEnabled && !endDate.HasValue) ? (DateTime?)EndDate.Date + EndTime : endDate;
             if (Calendars.Count == 0)

--- a/Samples/Samples/ViewModel/CalendarViewModel.cs
+++ b/Samples/Samples/ViewModel/CalendarViewModel.cs
@@ -191,8 +191,8 @@ namespace Samples.ViewModel
         {
             await Calendar.RequestCalendarReadAccess();
 
-            startDate = StartDatePickersEnabled && startDate == null ? (DateTime?)StartDate + StartTime : null;
-            endDate = EndDatePickersEnabled && endDate == null ? (DateTime?)EndDate + EndTime : null;
+            startDate = StartDatePickersEnabled && !startDate.HasValue ? (DateTime?)StartDate.Date + StartTime : startDate;
+            endDate = (EndDatePickersEnabled && !endDate.HasValue) ? (DateTime?)EndDate.Date + EndTime : endDate;
             if (Calendars.Count == 0)
                 return;
 

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Essentials
                 {
                     Id = e.CalendarItemIdentifier,
                     Title = e.Title,
-                    Description = e.Description,
+                    Description = e.Notes,
                     Location = e.Location,
                     Start = (long)Math.Floor((Math.Abs(NSDate.FromTimeIntervalSince1970(0).SecondsSinceReferenceDate) + e.StartDate.SecondsSinceReferenceDate) * 1000),
                     End = (long)Math.Floor((Math.Abs(NSDate.FromTimeIntervalSince1970(0).SecondsSinceReferenceDate) + e.EndDate.SecondsSinceReferenceDate) * 1000)

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -27,16 +27,50 @@ namespace Xamarin.Essentials
             return calendarList.AsReadOnly();
         }
 
-        static Task<IReadOnlyList<IEvent>> PlatformGetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null) => throw new NotImplementedException();
-
-        static async Task PlatformRequestCalendarReadAccess()
+        static async Task<IReadOnlyList<IEvent>> PlatformGetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
         {
             await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+            var systemAbsoluteReferenceDate = new DateTime(2001, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            var eventList = new List<Event>();
+            var startDateToConvert = startDate ?? DateTimeOffset.Now;
+            var endDateToConvert = endDate ?? startDateToConvert.AddYears(4);   // 4 years is the maximum period that a iOS calendar events can search
+            var sDate = NSDate.FromTimeIntervalSinceReferenceDate((startDateToConvert.UtcDateTime - systemAbsoluteReferenceDate).TotalSeconds);
+            var eDate = NSDate.FromTimeIntervalSinceReferenceDate((endDateToConvert.UtcDateTime - systemAbsoluteReferenceDate).TotalSeconds);
+            var calendars = !string.IsNullOrEmpty(calendarId) ? CalendarRequest.Instance.Calendars.Where(x => x.CalendarIdentifier == calendarId).ToArray() : null;
+            var query = CalendarRequest.Instance.PredicateForEvents(sDate, eDate, calendars);
+            var events = CalendarRequest.Instance.EventsMatching(query);
+
+            foreach (var e in events)
+            {
+                eventList.Add(new Event
+                {
+                    Id = e.CalendarItemIdentifier,
+                    Title = e.Title,
+                    Description = e.Description,
+                    Location = e.Location,
+                    Start = (long)Math.Floor((Math.Abs(NSDate.FromTimeIntervalSince1970(0).SecondsSinceReferenceDate) + e.StartDate.SecondsSinceReferenceDate) * 1000),
+                    End = (long)Math.Floor((Math.Abs(NSDate.FromTimeIntervalSince1970(0).SecondsSinceReferenceDate) + e.EndDate.SecondsSinceReferenceDate) * 1000)
+                });
+            }
+            eventList.Sort((x, y) =>
+            {
+                if (!x.StartDate.HasValue)
+                {
+                    if (!y.EndDate.HasValue)
+                    {
+                        return 0;
+                    }
+                    return -1;
+                }
+                return !y.EndDate.HasValue ? 1 : x.StartDate.Value.CompareTo(y.EndDate.Value);
+            });
+
+            return eventList.AsReadOnly();
         }
 
-        static async Task PlatformRequestCalendarWriteAccess()
-        {
-            await Permissions.RequireAsync(PermissionType.CalendarWrite);
-        }
+        static async Task PlatformRequestCalendarReadAccess() => await Permissions.RequireAsync(PermissionType.CalendarRead);
+
+        static async Task PlatformRequestCalendarWriteAccess() => await Permissions.RequireAsync(PermissionType.CalendarWrite);
     }
 }

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -47,8 +47,6 @@ namespace Xamarin.Essentials
                 {
                     Id = e.CalendarItemIdentifier,
                     Title = e.Title,
-                    Description = e.Notes,
-                    Location = e.Location,
                     Start = (long)Math.Floor((Math.Abs(NSDate.FromTimeIntervalSince1970(0).SecondsSinceReferenceDate) + e.StartDate.SecondsSinceReferenceDate) * 1000),
                     End = (long)Math.Floor((Math.Abs(NSDate.FromTimeIntervalSince1970(0).SecondsSinceReferenceDate) + e.EndDate.SecondsSinceReferenceDate) * 1000)
                 });


### PR DESCRIPTION
### Description of Change ###

Now able to pull back events for iOS

Fixed a bug that occurred when changing start/end date, where it would it would return null dates whilst being used to refresh the list.

Adjustments as per request to previous PR for feature/timespecificevents

Using PushAsync instead of PushModalAsync as this keeps the back button for iOS

Reduce noise from read access calls.

### Bugs Fixed ###

#20 #21 #22 #24 

### API Changes ###

Changed:

 - `static Task<IReadOnlyList<IEvent>>PlatformGetEventsAsync() NotImplemented` => `static async Task<IReadOnlyList<IEvent>> PlatformGetEventsAsync(string calendarId = null, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)`

### Behavioral Changes ###

iOS should now replicate behaviour of Android. 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation ([see walkthrough](https://github.com/xamarin/Essentials/wiki/Documenting-your-code-with-mdoc))
