### PR TITLE
Calendar no longer retrieves duration, but now calculates it based on…

### DIFF
--- a/Samples/Samples/View/CalendarEventPage.xaml
+++ b/Samples/Samples/View/CalendarEventPage.xaml
@@ -51,7 +51,8 @@
                    HorizontalTextAlignment="Center"/>
             <Label Grid.Column="2"
                    Grid.Row="2"
-                   Text="-"/>
+                   Text="-"
+                   IsVisible="{Binding AllDay, Converter={StaticResource NegativeConverter}}"/>
             <Label Grid.Column="3"
                    Grid.Row="2"
                    Text="{Binding EndDate, StringFormat={StaticResource DateDisplayFormatter}, Mode=OneWay}"

--- a/Samples/Samples/View/CalendarPage.xaml
+++ b/Samples/Samples/View/CalendarPage.xaml
@@ -33,7 +33,8 @@
                                    TextColor="Black"
                                    HorizontalTextAlignment="Center" />
                             <Label Grid.Column="2"
-                                   Text="-" />
+                                   Text="-"
+                                   IsVisible="{Binding AllDay, Converter={StaticResource NegativeConverter}}"/>
                             <Label Grid.Column="3"
                                    Text="{Binding EndDate, StringFormat={StaticResource DateDisplayFormatter}}"
                                    TextColor="Black"

--- a/Xamarin.Essentials/Calendar/Calendar.android.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.android.cs
@@ -140,7 +140,6 @@ namespace Xamarin.Essentials
                         Location = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.EventLocation)),
                         AllDay = cur.GetInt(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) == 1,
                         StartDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtstart))),
-                        Duration = TimeSpan.FromMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend)) - cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtstart))),
                         EndDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend))),
                         Attendees = GetAttendeesForEvent(eventId)
                     };

--- a/Xamarin.Essentials/Calendar/Calendar.android.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.android.cs
@@ -69,6 +69,7 @@ namespace Xamarin.Essentials
                 CalendarContract.Events.InterfaceConsts.Id,
                 CalendarContract.Events.InterfaceConsts.CalendarId,
                 CalendarContract.Events.InterfaceConsts.Title,
+                CalendarContract.Events.InterfaceConsts.AllDay,
                 CalendarContract.Events.InterfaceConsts.Dtstart,
                 CalendarContract.Events.InterfaceConsts.Dtend,
                 CalendarContract.Events.InterfaceConsts.Deleted
@@ -95,7 +96,7 @@ namespace Xamarin.Essentials
                         CalendarId = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.CalendarId)),
                         Title = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Title)),
                         StartDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtstart))),
-                        EndDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend)))
+                        EndDate = cur.GetInt(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) == 0 ? (DateTimeOffset?)DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend))) : null
                     });
                 }
                 return events;
@@ -138,9 +139,8 @@ namespace Xamarin.Essentials
                         Title = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Title)),
                         Description = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Description)),
                         Location = cur.GetString(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.EventLocation)),
-                        AllDay = cur.GetInt(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) == 1,
                         StartDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtstart))),
-                        EndDate = DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend))),
+                        EndDate = cur.GetInt(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.AllDay)) == 0 ? (DateTimeOffset?)DateTimeOffset.FromUnixTimeMilliseconds(cur.GetLong(eventsProjection.IndexOf(CalendarContract.Events.InterfaceConsts.Dtend))) : null,
                         Attendees = GetAttendeesForEvent(eventId)
                     };
                     return eventResult;

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -77,19 +77,11 @@ namespace Xamarin.Essentials
             }
             eventList.Sort((x, y) =>
             {
-                if (!x.StartDate.HasValue)
-                {
-                    if (!y.EndDate.HasValue)
-                    {
-                        return 0;
-                    }
-                    return -1;
-                }
                 if (!y.EndDate.HasValue)
                 {
-                    return 1;
+                    return 0;
                 }
-                return x.StartDate.Value.CompareTo(y.EndDate.Value);
+                return x.StartDate.CompareTo(y.EndDate.Value);
             });
 
             return eventList;

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Essentials
                     CalendarId = e.Calendar.CalendarIdentifier,
                     Title = e.Title,
                     StartDate = e.StartDate.ToDateTimeOffset(),
-                    EndDate = e.EndDate.ToDateTimeOffset()
+                    EndDate = !e.AllDay ? (DateTimeOffset?)e.EndDate.ToDateTimeOffset() : null
                 });
             }
             eventList.Sort((x, y) =>
@@ -109,8 +109,7 @@ namespace Xamarin.Essentials
                 Description = e.Notes,
                 Location = e.Location,
                 StartDate = e.StartDate.ToDateTimeOffset(),
-                EndDate = e.EndDate.ToDateTimeOffset(),
-                AllDay = e.AllDay,
+                EndDate = !e.AllDay ? (DateTimeOffset?)e.EndDate.ToDateTimeOffset() : null,
                 Attendees = e.Attendees != null ? GetAttendeesForEvent(e.Attendees) : new List<DeviceEventAttendee>()
             };
         }

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -117,7 +117,6 @@ namespace Xamarin.Essentials
                 Description = e.Notes,
                 Location = e.Location,
                 StartDate = e.StartDate.ToDateTimeOffset(),
-                Duration = e.EndDate.ToDateTimeOffset() - e.StartDate.ToDateTimeOffset(),
                 EndDate = e.EndDate.ToDateTimeOffset(),
                 AllDay = e.AllDay,
                 Attendees = e.Attendees != null ? GetAttendeesForEvent(e.Attendees) : new List<DeviceEventAttendee>()

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -63,7 +63,11 @@ namespace Xamarin.Essentials
             }
             eventList.Sort((x, y) =>
             {
-                return x.StartDate.CompareTo(y.EndDate);
+                if (!y.EndDate.HasValue)
+                {
+                    return 0;
+                }
+                return x.StartDate.CompareTo(y.EndDate.Value);
             });
 
             return eventList;

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -106,7 +106,6 @@ namespace Xamarin.Essentials
                 Description = e.Details,
                 Location = e.Location,
                 StartDate = e.StartTime,
-                Duration = e.Duration,
                 EndDate = e.StartTime.Add(e.Duration),
                 AllDay = e.AllDay,
                 Attendees = GetAttendeesForEvent(e.Invitees)

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Essentials
             options.FetchProperties.Add(AppointmentProperties.Subject);
             options.FetchProperties.Add(AppointmentProperties.StartTime);
             options.FetchProperties.Add(AppointmentProperties.Duration);
+            options.FetchProperties.Add(AppointmentProperties.AllDay);
             var sDate = startDate ?? DateTimeOffset.Now.Add(defaultStartTimeFromNow);
             var eDate = endDate ?? sDate.Add(defaultEndTimeFromStartTime);
 
@@ -57,7 +58,7 @@ namespace Xamarin.Essentials
                         CalendarId = e.CalendarId,
                         Title = e.Subject,
                         StartDate = e.StartTime,
-                        EndDate = e.StartTime.Add(e.Duration)
+                        EndDate = !e.AllDay ? (DateTimeOffset?)e.StartTime.Add(e.Duration) : null,
                     });
                 }
             }
@@ -102,8 +103,7 @@ namespace Xamarin.Essentials
                 Description = e.Details,
                 Location = e.Location,
                 StartDate = e.StartTime,
-                EndDate = e.StartTime.Add(e.Duration),
-                AllDay = e.AllDay,
+                EndDate = !e.AllDay ? (DateTimeOffset?)e.StartTime.Add(e.Duration) : null,
                 Attendees = GetAttendeesForEvent(e.Invitees)
             };
         }

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -63,15 +63,7 @@ namespace Xamarin.Essentials
             }
             eventList.Sort((x, y) =>
             {
-                if (!x.StartDate.HasValue)
-                {
-                    if (!y.EndDate.HasValue)
-                    {
-                        return 0;
-                    }
-                    return -1;
-                }
-                return !y.EndDate.HasValue ? 1 : x.StartDate.Value.CompareTo(y.EndDate.Value);
+                return x.StartDate.CompareTo(y.EndDate);
             });
 
             return eventList;

--- a/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
+++ b/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
@@ -28,11 +28,15 @@ namespace Xamarin.Essentials
 
         public bool AllDay { get; set; }
 
-        public DateTimeOffset? StartDate { get; set; }
+        public DateTimeOffset StartDate { get; set; }
 
-        public TimeSpan Duration => EndDate.HasValue && StartDate.HasValue ? EndDate.Value - StartDate.Value : TimeSpan.Zero;
+        public TimeSpan Duration
+        {
+            get => EndDate - StartDate;
+            set => EndDate = StartDate.Add(value);
+        }
 
-        public DateTimeOffset? EndDate { get; set; }
+        public DateTimeOffset EndDate { get; set; }
 
         public List<DeviceEventAttendee> Attendees { get; set; }
     }

--- a/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
+++ b/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Essentials
 
         public DateTimeOffset? StartDate { get; set; }
 
-        public TimeSpan Duration { get; set; }
+        public TimeSpan Duration => EndDate.HasValue && StartDate.HasValue ? EndDate.Value - StartDate.Value : TimeSpan.Zero;
 
         public DateTimeOffset? EndDate { get; set; }
 

--- a/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
+++ b/Xamarin.Essentials/Types/DeviceCalendar.shared.cs
@@ -26,17 +26,41 @@ namespace Xamarin.Essentials
 
         public string Location { get; set; }
 
-        public bool AllDay { get; set; }
+        public bool AllDay
+        {
+            get => !EndDate.HasValue;
+            set
+            {
+                if (value)
+                {
+                    EndDate = null;
+                }
+                else
+                {
+                    EndDate = StartDate;
+                }
+            }
+        }
 
         public DateTimeOffset StartDate { get; set; }
 
-        public TimeSpan Duration
+        public TimeSpan? Duration
         {
-            get => EndDate - StartDate;
-            set => EndDate = StartDate.Add(value);
+            get => EndDate.HasValue ? EndDate - StartDate : null;
+            set
+            {
+                if (value.HasValue)
+                {
+                    EndDate = StartDate.Add(value.Value);
+                }
+                else
+                {
+                    EndDate = null;
+                }
+            }
         }
 
-        public DateTimeOffset EndDate { get; set; }
+        public DateTimeOffset? EndDate { get; set; }
 
         public List<DeviceEventAttendee> Attendees { get; set; }
     }


### PR DESCRIPTION
meeting PR feedback to convert Duration to a value getter rather than fetching the value.

see:
https://github.com/builttoroam/Essentials/pull/33/files/5b3fa96cd2f2484acaa46faaee1b32f5a7b9d1e7..a5ebd36187964b81a8162d763f1b8bc2fb642bff#diff-bc1e295614ef74c0ce03e4639b1bc195

Note: When either a start or end date is missing duration will return 0 as it's unknown, this could be nullable otherwise?