### PR TITLE
GetEventsAsync was not experiencing the same behaviour across platforms when passed in a fake calendar id

### DIFF
--- a/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
@@ -35,6 +35,20 @@ namespace DeviceTests
 
         [Theory]
         [InlineData("ThisIsAFakeId")]
+        [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+        public Task Get_Events_By_Bad_Calendar_Text_Id(string calendarId)
+        {
+            return Utils.OnMainThread(async () =>
+            {
+#if __ANDROID__
+                await Assert.ThrowsAsync<ArgumentException>(() => Calendar.GetEventsAsync(calendarId));
+#else
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Calendar.GetEventsAsync(calendarId));
+#endif
+            });
+        }
+
+        [Theory]
         [InlineData("-1")]
         [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
         public Task Get_Events_By_Bad_Calendar_Id(string calendarId)
@@ -46,18 +60,38 @@ namespace DeviceTests
         }
 
         [Theory]
-        [InlineData("ThisIsAFakeId")]
-        [InlineData("-1")]
         [InlineData("")]
+        [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+        public Task Get_Event_By_Blank_Id(string eventId)
+        {
+            return Utils.OnMainThread(async () =>
+            {
+                await Assert.ThrowsAsync<ArgumentException>(() => Calendar.GetEventByIdAsync(eventId));
+            });
+        }
+
+        [Theory]
+        [InlineData("-1")]
         [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
         public Task Get_Event_By_Bad_Id(string eventId)
         {
             return Utils.OnMainThread(async () =>
             {
-#if __IOS__
-                await Assert.ThrowsAsync<NullReferenceException>(() => Calendar.GetEventByIdAsync(eventId));
-#else
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Calendar.GetEventByIdAsync(eventId));
+            });
+        }
+
+        [Theory]
+        [InlineData("ThisIsAFakeId")]
+        [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+        public Task Get_Event_By_Bad_Text_Id(string eventId)
+        {
+            return Utils.OnMainThread(async () =>
+            {
+#if __ANDROID__
                 await Assert.ThrowsAsync<ArgumentException>(() => Calendar.GetEventByIdAsync(eventId));
+#else
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Calendar.GetEventByIdAsync(eventId));
 #endif
             });
         }

--- a/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
@@ -41,8 +41,7 @@ namespace DeviceTests
         {
             return Utils.OnMainThread(async () =>
             {
-                var eventList = await Calendar.GetEventsAsync(calendarId);
-                Assert.Empty(eventList);
+                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Calendar.GetEventsAsync(calendarId));
             });
         }
 

--- a/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
@@ -36,16 +36,29 @@ namespace DeviceTests
         [Theory]
         [InlineData("ThisIsAFakeId")]
         [InlineData("-1")]
+        [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
+        public Task Get_Events_By_Bad_Calendar_Id(string calendarId)
+        {
+            return Utils.OnMainThread(async () =>
+            {
+                var eventList = await Calendar.GetEventsAsync(calendarId);
+                Assert.Empty(eventList);
+            });
+        }
+
+        [Theory]
+        [InlineData("ThisIsAFakeId")]
+        [InlineData("-1")]
         [InlineData("")]
         [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
-        public Task Get_Event_By_Bad_Id(string calendarId)
+        public Task Get_Event_By_Bad_Id(string eventId)
         {
             return Utils.OnMainThread(async () =>
             {
 #if __IOS__
-                await Assert.ThrowsAsync<NullReferenceException>(() => Calendar.GetEventByIdAsync(calendarId));
+                await Assert.ThrowsAsync<NullReferenceException>(() => Calendar.GetEventByIdAsync(eventId));
 #else
-                await Assert.ThrowsAsync<ArgumentException>(() => Calendar.GetEventByIdAsync(calendarId));
+                await Assert.ThrowsAsync<ArgumentException>(() => Calendar.GetEventByIdAsync(eventId));
 #endif
             });
         }

--- a/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
+++ b/DeviceTests/DeviceTests.Shared/Calendar_Tests.cs
@@ -61,6 +61,7 @@ namespace DeviceTests
 
         [Theory]
         [InlineData("")]
+        [InlineData(null)]
         [Trait(Traits.InteractionType, Traits.InteractionTypes.Human)]
         public Task Get_Event_By_Blank_Id(string eventId)
         {

--- a/Xamarin.Essentials/Calendar/Calendar.android.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.android.cs
@@ -60,7 +60,12 @@ namespace Xamarin.Essentials
             var eDate = endDate ?? sDate.Add(defaultEndTimeFromStartTime);
             if (!string.IsNullOrEmpty(calendarId))
             {
-                calendarSpecificEvent = $"{CalendarContract.Events.InterfaceConsts.CalendarId}={calendarId} {andCondition} ";
+                // Match other platforms where if you pass in a bad id return an empty list, this must be a bad id as android ids can only be integers.
+                if (!int.TryParse(calendarId, out var resultId))
+                {
+                    return new List<DeviceEvent>();
+                }
+                calendarSpecificEvent = $"{CalendarContract.Events.InterfaceConsts.CalendarId}={resultId} {andCondition} ";
             }
             calendarSpecificEvent += $"{CalendarContract.Events.InterfaceConsts.Dtend} >= {sDate.AddMilliseconds(sDate.Offset.TotalMilliseconds).ToUnixTimeMilliseconds()} {andCondition} ";
             calendarSpecificEvent += $"{CalendarContract.Events.InterfaceConsts.Dtstart} <= {eDate.AddMilliseconds(sDate.Offset.TotalMilliseconds).ToUnixTimeMilliseconds()} {andCondition} ";

--- a/Xamarin.Essentials/Calendar/Calendar.android.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.android.cs
@@ -93,14 +93,6 @@ namespace Xamarin.Essentials
                 {
                     GetCalendarById(calendarId);
                 }
-                catch (ArgumentOutOfRangeException)
-                {
-                    throw;
-                }
-                catch (ArgumentException)
-                {
-                    throw;
-                }
                 catch (Exception)
                 {
                     throw new ArgumentOutOfRangeException($"[Android]: No calendar exists with the Id {calendarId}");

--- a/Xamarin.Essentials/Calendar/Calendar.android.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.android.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Essentials
             var eDate = endDate ?? sDate.Add(defaultEndTimeFromStartTime);
             if (!string.IsNullOrEmpty(calendarId))
             {
-                // Match other platforms where if you pass in a bad id return an empty list, this must be a bad id as android ids can only be integers.
+                // Match other platforms where if you pass in a bad id return an empty list, this must be a bad id as android calendar ids can only be integers.
                 if (!int.TryParse(calendarId, out var resultId))
                 {
                     return new List<DeviceEvent>();

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -71,26 +71,29 @@ namespace Xamarin.Essentials
         {
             await Permissions.RequireAsync(PermissionType.CalendarRead);
 
-            EKEvent e;
-            try
+            var calendarEvent = CalendarRequest.Instance.GetCalendarItem(eventId) as EKEvent;
+            if (calendarEvent == null)
             {
-                e = CalendarRequest.Instance.GetCalendarItem(eventId) as EKEvent;
-            }
-            catch (NullReferenceException)
-            {
-                throw new NullReferenceException($"[iOS]: No Event found for event Id {eventId}");
+                if (string.IsNullOrWhiteSpace(eventId))
+                {
+                    throw new ArgumentException($"[iOS]: No Event found for event Id {eventId}");
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException($"[iOS]: No Event found for event Id {eventId}");
+                }
             }
 
             return new DeviceEvent
             {
-                Id = e.CalendarItemIdentifier,
-                CalendarId = e.Calendar.CalendarIdentifier,
-                Title = e.Title,
-                Description = e.Notes,
-                Location = e.Location,
-                StartDate = e.StartDate.ToDateTimeOffset(),
-                EndDate = !e.AllDay ? (DateTimeOffset?)e.EndDate.ToDateTimeOffset() : null,
-                Attendees = e.Attendees != null ? GetAttendeesForEvent(e.Attendees) : new List<DeviceEventAttendee>()
+                Id = calendarEvent.CalendarItemIdentifier,
+                CalendarId = calendarEvent.Calendar.CalendarIdentifier,
+                Title = calendarEvent.Title,
+                Description = calendarEvent.Notes,
+                Location = calendarEvent.Location,
+                StartDate = calendarEvent.StartDate.ToDateTimeOffset(),
+                EndDate = !calendarEvent.AllDay ? (DateTimeOffset?)calendarEvent.EndDate.ToDateTimeOffset() : null,
+                Attendees = calendarEvent.Attendees != null ? GetAttendeesForEvent(calendarEvent.Attendees) : new List<DeviceEventAttendee>()
             };
         }
 

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -40,13 +40,14 @@ namespace Xamarin.Essentials
             var endDateToConvert = endDate ?? startDateToConvert.Add(defaultEndTimeFromStartTime);  // NOTE: 4 years is the maximum period that a iOS calendar events can search
             var sDate = startDateToConvert.ToNSDate();
             var eDate = endDateToConvert.ToNSDate();
-            EKCalendar[] calendars;
-            calendars = !string.IsNullOrWhiteSpace(calendarId)
-                ? CalendarRequest.Instance.Calendars.Where(x => x.CalendarIdentifier == calendarId).ToArray()
-                : null;
+            EKCalendar[] calendars = null;
+            if (!string.IsNullOrWhiteSpace(calendarId))
+            {
+                calendars = CalendarRequest.Instance.Calendars.Where(x => x.CalendarIdentifier == calendarId).ToArray();
 
-            if (calendars.Length == 0 && !string.IsNullOrWhiteSpace(calendarId))
-                return new List<DeviceEvent>();
+                if (calendars.Length == 0 && !string.IsNullOrWhiteSpace(calendarId))
+                    throw new ArgumentOutOfRangeException($"[iOS]: No calendar exists with the Id {calendarId}");
+            }
 
             var query = CalendarRequest.Instance.PredicateForEvents(sDate, eDate, calendars);
             var events = CalendarRequest.Instance.EventsMatching(query);

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -41,16 +41,12 @@ namespace Xamarin.Essentials
             var sDate = startDateToConvert.ToNSDate();
             var eDate = endDateToConvert.ToNSDate();
             EKCalendar[] calendars;
-            try
-            {
-                calendars = !string.IsNullOrWhiteSpace(calendarId)
-                    ? CalendarRequest.Instance.Calendars.Where(x => x.CalendarIdentifier == calendarId).ToArray()
-                    : null;
-            }
-            catch (NullReferenceException ex)
-            {
-                throw new NullReferenceException($"iOS: Unexpected null reference exception {ex.Message}");
-            }
+            calendars = !string.IsNullOrWhiteSpace(calendarId)
+                ? CalendarRequest.Instance.Calendars.Where(x => x.CalendarIdentifier == calendarId).ToArray()
+                : null;
+
+            if (calendars.Length == 0 && !string.IsNullOrWhiteSpace(calendarId))
+                return new List<DeviceEvent>();
 
             var query = CalendarRequest.Instance.PredicateForEvents(sDate, eDate, calendars);
             var events = CalendarRequest.Instance.EventsMatching(query);

--- a/Xamarin.Essentials/Calendar/Calendar.ios.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.ios.cs
@@ -71,17 +71,15 @@ namespace Xamarin.Essentials
         {
             await Permissions.RequireAsync(PermissionType.CalendarRead);
 
+            if (string.IsNullOrWhiteSpace(eventId))
+            {
+                throw new ArgumentException($"[iOS]: No Event found for event Id {eventId}");
+            }
+
             var calendarEvent = CalendarRequest.Instance.GetCalendarItem(eventId) as EKEvent;
             if (calendarEvent == null)
             {
-                if (string.IsNullOrWhiteSpace(eventId))
-                {
-                    throw new ArgumentException($"[iOS]: No Event found for event Id {eventId}");
-                }
-                else
-                {
-                    throw new ArgumentOutOfRangeException($"[iOS]: No Event found for event Id {eventId}");
-                }
+                throw new ArgumentOutOfRangeException($"[iOS]: No Event found for event Id {eventId}");
             }
 
             return new DeviceEvent

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Essentials
         {
             await Permissions.RequireAsync(PermissionType.CalendarRead);
 
-            var options = new FindAppointmentsOptions();
+          var options = new FindAppointmentsOptions();
             options.FetchProperties.Add(AppointmentProperties.Subject);
             options.FetchProperties.Add(AppointmentProperties.StartTime);
             options.FetchProperties.Add(AppointmentProperties.Duration);

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Essentials
         {
             await Permissions.RequireAsync(PermissionType.CalendarRead);
 
-          var options = new FindAppointmentsOptions();
+            var options = new FindAppointmentsOptions();
             options.FetchProperties.Add(AppointmentProperties.Subject);
             options.FetchProperties.Add(AppointmentProperties.StartTime);
             options.FetchProperties.Add(AppointmentProperties.Duration);

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -56,7 +56,32 @@ namespace Xamarin.Essentials
                             .OrderBy(e => e.StartDate)
                             .ToList();
 
+            if (eventList.Count == 0 && !string.IsNullOrWhiteSpace(calendarId))
+            {
+                await GetCalendarById(calendarId);
+            }
+
             return eventList;
+        }
+
+        static async Task<DeviceCalendar> GetCalendarById(string calendarId)
+        {
+            var instance = await CalendarRequest.GetInstanceAsync();
+            var uwpCalendarList = await instance.FindAppointmentCalendarsAsync(FindAppointmentCalendarsOptions.IncludeHidden);
+
+            var result = (from calendar in uwpCalendarList
+                             select new DeviceCalendar
+                             {
+                                 Id = calendar.LocalId,
+                                 Name = calendar.DisplayName
+                             })
+                             .Where(c => c.Id == calendarId).FirstOrDefault();
+            if (result == null)
+            {
+                throw new ArgumentOutOfRangeException($"[UWP]: No calendar exists with the Id {calendarId}");
+            }
+
+            return result;
         }
 
         static async Task<DeviceEvent> PlatformGetEventByIdAsync(string eventId)

--- a/Xamarin.Essentials/Calendar/Calendar.uwp.cs
+++ b/Xamarin.Essentials/Calendar/Calendar.uwp.cs
@@ -98,11 +98,14 @@ namespace Xamarin.Essentials
             }
             catch (ArgumentException)
             {
-                throw new ArgumentException($"[UWP]: No Event found for event Id {eventId}");
-            }
-            catch (NullReferenceException)
-            {
-                throw new NullReferenceException($"[UWP]: No Event found for event Id {eventId}");
+                if (string.IsNullOrWhiteSpace(eventId))
+                {
+                    throw new ArgumentException($"[UWP]: No Event found for event Id {eventId}");
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException($"[UWP]: No Event found for event Id {eventId}");
+                }
             }
 
             return new DeviceEvent()


### PR DESCRIPTION
- Android was throwing an exception upon getting a non-integer parameter
- iOS was treating any fake id as having no id and pulling back all events
- Now all platforms will pull back no events when a bad id is used